### PR TITLE
Enable image loading and gallery for canvas coloring app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎨 Coloréame — MVP (SPA Vanilla)
 
-Coloréame es una aplicación web **SPA sin frameworks** para colorear imágenes (PNG/JPG) usando HTML5 Canvas.  
+Coloréame es una aplicación web **SPA sin frameworks** para colorear imágenes (PNG/JPG) usando HTML5 Canvas.
 Todo funciona **localmente en el navegador**, sin backend, y puede desplegarse fácilmente en **GitHub Pages**.
 
 ## 🚀 Características (MVP)
@@ -16,25 +16,22 @@ Todo funciona **localmente en el navegador**, sin backend, y puede desplegarse f
 / (raíz)
 ├─ index.html
 ├─ /css
-│  ├─ styles.css
-│  ├─ components.css
-│  └─ utilities.css
+│  └─ style.css
 ├─ /js
-│  ├─ app.js
+│  ├─ main.js
 │  ├─ state.js
-│  ├─ /ui
+│  ├─ /tools
 │  ├─ /services
+│  ├─ /ui
 │  └─ /utils
 ├─ /workers
 │  └─ floodFill.js
 ├─ /assets
-│  ├─ samples/
-│  └─ icons/
 ├─ /tests
-│  ├─ index.html
 │  ├─ runner.js
 │  ├─ assert.js
-│  └─ *.test.js
+│  ├─ history.test.js
+│  └─ storage.test.js
 ├─ /docs
 │  ├─ USO.md
 │  └─ TECNICO.md
@@ -43,8 +40,7 @@ Todo funciona **localmente en el navegador**, sin backend, y puede desplegarse f
 
 ## 🧪 Pruebas unitarias
 - Se encuentran en `/tests`.
-- Se ejecutan en el navegador abriendo `tests/index.html`.
-- Orquestadas por `runner.js` con aserciones básicas (`assert`, `equal`, `deepEqual`, `throws`).
+- Se ejecutan con `npm test`.
 
 ## 🌐 Despliegue en GitHub Pages
 1. Sube este repo a GitHub.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,28 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.toolbar {
+  background: #f0f0f0;
+  padding: 8px;
+  display: flex;
+  gap: 4px;
+}
+
+.palette button {
+  width: 20px;
+  height: 20px;
+  border: 1px solid #000;
+  margin: 0 2px;
+  cursor: pointer;
+}
+
+#canvas {
+  flex: 1;
+  border: 1px solid #ccc;
+  cursor: crosshair;
+}

--- a/docs/PLAN_MVP.md
+++ b/docs/PLAN_MVP.md
@@ -1,0 +1,30 @@
+# Plan para el MVP de Coloréame
+
+1. **Estructura inicial del proyecto**
+   - Crear las carpetas descritas: `css/`, `js/`, `workers/`, `assets/`, `tests/` y `docs/`.
+   - Incluir `index.html` y hojas de estilo base.
+
+2. **Estado global y servicios**
+   - Implementar `state.js` para manejar herramienta activa, color, tamaño de pincel, tolerancia y pila de historial.
+   - Desarrollar servicios para cargar imágenes, gestionar el canvas, historial, exportación y almacenamiento en LocalStorage.
+
+3. **Interfaz de usuario**
+   - Construir componentes en `/ui` para la barra de herramientas, paleta de colores y vista del canvas.
+   - Integrar un selector avanzado de color.
+
+4. **Herramientas de dibujo**
+   - Implementar el **pincel** con tamaño configurable.
+   - Crear el **bote de pintura** con algoritmo de flood fill y tolerancia; opcionalmente usar un Web Worker.
+   - Añadir **borrador** que remueva el color agregado.
+
+5. **Historial y exportación**
+   - Gestionar deshacer/rehacer hasta 20 pasos.
+   - Exportar el canvas final a PNG.
+
+6. **Pruebas unitarias**
+   - Escribir pruebas para utilidades y servicios clave en `/tests` usando `runner.js` y `assert.js`.
+
+7. **Documentación y despliegue**
+   - Completar guía de uso y notas técnicas.
+   - Preparar publicación en GitHub Pages desde la rama `main`.
+

--- a/docs/README_RESUMEN.md
+++ b/docs/README_RESUMEN.md
@@ -1,0 +1,12 @@
+# Resumen del README
+
+Coloréame es una aplicación web SPA sin frameworks para colorear imágenes usando HTML5 Canvas. El MVP propone:
+
+- Cargar imágenes locales y una galería de ejemplos.
+- Herramientas de pincel, bote de pintura con tolerancia y borrador.
+- Paleta de colores con selector avanzado.
+- Historial de deshacer/rehacer hasta 20 pasos.
+- Exportación a PNG.
+
+La estructura del proyecto incluye carpetas para `css`, `js` (con `state.js`, servicios, UI y utilidades), `workers` para operaciones pesadas, `assets` con muestras e iconos y `tests` para pruebas unitarias en el navegador. La documentación adicional se encuentra en `docs/`.
+

--- a/docs/TECNICO_RESUMEN.md
+++ b/docs/TECNICO_RESUMEN.md
@@ -1,0 +1,12 @@
+# Resumen de TECNICO.md
+
+La arquitectura del proyecto es una SPA sin frameworks que usa la API Canvas 2D y persistencia ligera con LocalStorage. La lógica se divide en:
+
+- `state.js` para el estado global (herramienta, color, tolerancia, historial).
+- `/services` para la lógica de negocio (canvas, imágenes, exportación, historial, storage).
+- `/ui` para componentes de interfaz.
+- `/utils` con helpers puros.
+- `/workers` para operaciones pesadas opcionales como el flood fill.
+
+Limitaciones principales: lienzo hasta 1920×1080 px, historial de 20 pasos y posible lentitud del flood fill en imágenes grandes. Es compatible con los navegadores modernos en desktop y móvil (Chrome, Firefox, Edge, Safari, Safari iOS ≥ 13) y no envía datos a servidores externos. Las pruebas unitarias se ubican en `/tests` y se ejecutan en el navegador mediante `runner.js` y `assert.js`.
+

--- a/docs/USO_RESUMEN.md
+++ b/docs/USO_RESUMEN.md
@@ -1,0 +1,16 @@
+# Resumen de USO.md
+
+Coloréame permite colorear imágenes PNG o JPG directamente en el navegador. Flujo básico:
+
+1. Abrir la aplicación.
+2. Cargar una imagen propia o usar una de ejemplo.
+3. Utilizar herramientas:
+   - **Pincel** para dibujar con color y tamaño ajustables.
+   - **Bote de pintura** con tolerancia para rellenar.
+   - **Borrador** que elimina el color agregado.
+4. Cambiar de color desde la paleta o un selector avanzado.
+5. Deshacer/Rehacer para corregir.
+6. Exportar a PNG el resultado final.
+
+Atajos de teclado: `1` Pincel, `2` Bote, `3` Borrador, `Z` Deshacer, `Y` Rehacer. Se recomienda usar imágenes PNG con bordes nítidos y ajustar la tolerancia en JPG, con un tamaño máximo de 1920×1080 px.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Coloréame Canvas</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div id="toolbar" class="toolbar">
+    <select id="gallery">
+      <option value="">Galería</option>
+      <option value="house">Casa</option>
+      <option value="smiley">Carita</option>
+    </select>
+    <input type="file" id="imageLoader" accept="image/png,image/jpeg">
+    <button id="brush">Pincel</button>
+    <button id="bucket">Bote</button>
+    <button id="eraser">Borrador</button>
+    <div id="palette" class="palette"></div>
+    <input type="color" id="colorPicker" value="#000000">
+    <input type="number" id="brushSize" min="1" max="100" value="10">
+    <button id="undo">Deshacer</button>
+    <button id="redo">Rehacer</button>
+    <button id="export">Exportar</button>
+  </div>
+  <canvas id="canvas" width="800" height="600"></canvas>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,73 @@
+import { state } from './state.js';
+import { canvas, ctx, resize, getImage, putImage } from './services/canvasService.js';
+import { initToolbar } from './ui/toolbar.js';
+import { initPalette } from './ui/palette.js';
+import { startBrush, drawBrush, endBrush } from './tools/brush.js';
+import { eraseStart, eraseDraw, eraseEnd } from './tools/eraser.js';
+import { bucketFill } from './tools/bucket.js';
+
+resize(800, 600);
+initToolbar();
+initPalette();
+state.history.push(getImage());
+
+let drawing = false;
+
+canvas.addEventListener('mousedown', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  if (state.tool === 'brush') {
+    drawing = true;
+    startBrush(x, y);
+  } else if (state.tool === 'eraser') {
+    drawing = true;
+    eraseStart(x, y);
+  } else if (state.tool === 'bucket') {
+    bucketFill(x, y);
+  }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+  if (!drawing) return;
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  if (state.tool === 'brush') {
+    drawBrush(x, y);
+  } else if (state.tool === 'eraser') {
+    eraseDraw(x, y);
+  }
+});
+
+canvas.addEventListener('mouseup', () => {
+  if (drawing) {
+    if (state.tool === 'brush') endBrush();
+    if (state.tool === 'eraser') eraseEnd();
+    state.history.push(getImage());
+  }
+  drawing = false;
+});
+
+canvas.addEventListener('mouseleave', () => {
+  if (drawing) {
+    if (state.tool === 'brush') endBrush();
+    if (state.tool === 'eraser') eraseEnd();
+    state.history.push(getImage());
+  }
+  drawing = false;
+});
+
+// Undo/redo buttons
+const undoBtn = document.getElementById('undo');
+const redoBtn = document.getElementById('redo');
+
+undoBtn.onclick = () => {
+  const img = state.history.undo();
+  if (img) putImage(img);
+};
+
+redoBtn.onclick = () => {
+  const img = state.history.redo();
+  if (img) putImage(img);
+};

--- a/js/services/canvasService.js
+++ b/js/services/canvasService.js
@@ -1,0 +1,43 @@
+export const canvas = document.getElementById('canvas');
+export const ctx = canvas.getContext('2d');
+
+export function resize(width, height) {
+  canvas.width = width;
+  canvas.height = height;
+}
+
+export function clear() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+}
+
+export function getImage() {
+  return ctx.getImageData(0, 0, canvas.width, canvas.height);
+}
+
+export function putImage(data) {
+  ctx.putImageData(data, 0, 0);
+}
+
+export function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      resize(img.width, img.height);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0);
+      resolve();
+    };
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+export function loadFile(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => loadImage(reader.result).then(resolve).catch(reject);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/js/services/exportService.js
+++ b/js/services/exportService.js
@@ -1,0 +1,8 @@
+import { canvas } from './canvasService.js';
+
+export function exportPNG() {
+  const link = document.createElement('a');
+  link.download = 'canvas.png';
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}

--- a/js/services/galleryService.js
+++ b/js/services/galleryService.js
@@ -1,0 +1,43 @@
+import { ctx, resize, clear, getImage } from './canvasService.js';
+import { state } from '../state.js';
+
+function baseSetup(width, height) {
+  resize(width, height);
+  clear();
+  ctx.fillStyle = '#FFFFFF';
+  ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  ctx.strokeStyle = '#000000';
+  ctx.lineWidth = 2;
+}
+
+function drawHouse() {
+  baseSetup(400, 300);
+  ctx.strokeRect(100, 150, 200, 100);
+  ctx.beginPath();
+  ctx.moveTo(100, 150);
+  ctx.lineTo(200, 80);
+  ctx.lineTo(300, 150);
+  ctx.closePath();
+  ctx.stroke();
+}
+
+function drawSmiley() {
+  baseSetup(300, 300);
+  ctx.beginPath();
+  ctx.arc(150, 150, 100, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(110, 120, 10, 0, Math.PI * 2);
+  ctx.arc(190, 120, 10, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(150, 170, 60, 0, Math.PI);
+  ctx.stroke();
+}
+
+export function loadExample(name) {
+  if (name === 'house') drawHouse();
+  else if (name === 'smiley') drawSmiley();
+  state.history.clear();
+  state.history.push(getImage());
+}

--- a/js/services/historyService.js
+++ b/js/services/historyService.js
@@ -1,0 +1,40 @@
+const MAX_HISTORY = 20;
+
+export default class History {
+  constructor() {
+    this.stack = [];
+    this.index = -1;
+  }
+
+  push(data) {
+    if (this.index < this.stack.length - 1) {
+      this.stack = this.stack.slice(0, this.index + 1);
+    }
+    this.stack.push(data);
+    if (this.stack.length > MAX_HISTORY) {
+      this.stack.shift();
+    }
+    this.index = this.stack.length - 1;
+  }
+
+  undo() {
+    if (this.index > 0) {
+      this.index--;
+      return this.stack[this.index];
+    }
+    return null;
+  }
+
+  redo() {
+    if (this.index < this.stack.length - 1) {
+      this.index++;
+      return this.stack[this.index];
+    }
+    return null;
+  }
+
+  clear() {
+    this.stack = [];
+    this.index = -1;
+  }
+}

--- a/js/services/storageService.js
+++ b/js/services/storageService.js
@@ -1,0 +1,18 @@
+const storage = typeof localStorage !== 'undefined'
+  ? localStorage
+  : (() => {
+      const data = {};
+      return {
+        setItem: (k, v) => (data[k] = v),
+        getItem: (k) => data[k] || null,
+      };
+    })();
+
+export function save(key, value) {
+  storage.setItem(key, JSON.stringify(value));
+}
+
+export function load(key, defaultValue) {
+  const raw = storage.getItem(key);
+  return raw ? JSON.parse(raw) : defaultValue;
+}

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,21 @@
+import History from './services/historyService.js';
+
+export const state = {
+  tool: 'bucket',
+  color: '#000000',
+  brushSize: 10,
+  tolerance: 32,
+  history: new History()
+};
+
+export function setTool(t) {
+  state.tool = t;
+}
+
+export function setColor(c) {
+  state.color = c;
+}
+
+export function setBrushSize(s) {
+  state.brushSize = s;
+}

--- a/js/tools/brush.js
+++ b/js/tools/brush.js
@@ -1,0 +1,19 @@
+import { state } from '../state.js';
+import { ctx } from '../services/canvasService.js';
+
+export function startBrush(x, y) {
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.strokeStyle = state.color;
+  ctx.lineWidth = state.brushSize;
+  ctx.lineCap = 'round';
+}
+
+export function drawBrush(x, y) {
+  ctx.lineTo(x, y);
+  ctx.stroke();
+}
+
+export function endBrush() {
+  ctx.closePath();
+}

--- a/js/tools/bucket.js
+++ b/js/tools/bucket.js
@@ -1,0 +1,39 @@
+import { state } from '../state.js';
+import { ctx } from '../services/canvasService.js';
+import { floodFill } from '../utils/floodFill.js';
+
+let worker = null;
+if (window.Worker) {
+  try {
+    worker = new Worker('../workers/floodFill.js', { type: 'module' });
+  } catch (e) {
+    worker = null;
+  }
+}
+
+export function bucketFill(x, y) {
+  const image = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);
+  const fillColor = hexToRgba(state.color);
+  if (worker) {
+    worker.postMessage({ imageData: image, x, y, color: fillColor, tolerance: state.tolerance });
+    worker.onmessage = (e) => {
+      ctx.putImageData(e.data, 0, 0);
+      state.history.push(ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height));
+    };
+  } else {
+    floodFill(image, x, y, fillColor, state.tolerance);
+    ctx.putImageData(image, 0, 0);
+    state.history.push(ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height));
+  }
+}
+
+function hexToRgba(hex) {
+  hex = hex.replace('#', '');
+  const bigint = parseInt(hex, 16);
+  return [
+    (bigint >> 16) & 255,
+    (bigint >> 8) & 255,
+    bigint & 255,
+    255,
+  ];
+}

--- a/js/tools/eraser.js
+++ b/js/tools/eraser.js
@@ -1,0 +1,21 @@
+import { state } from '../state.js';
+import { ctx } from '../services/canvasService.js';
+
+export function eraseStart(x, y) {
+  ctx.save();
+  ctx.globalCompositeOperation = 'destination-out';
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineWidth = state.brushSize;
+  ctx.lineCap = 'round';
+}
+
+export function eraseDraw(x, y) {
+  ctx.lineTo(x, y);
+  ctx.stroke();
+}
+
+export function eraseEnd() {
+  ctx.closePath();
+  ctx.restore();
+}

--- a/js/ui/palette.js
+++ b/js/ui/palette.js
@@ -1,0 +1,14 @@
+import { setColor } from '../state.js';
+
+export function initPalette() {
+  const colors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FFA500', '#800080'];
+  const container = document.getElementById('palette');
+  colors.forEach(c => {
+    const btn = document.createElement('button');
+    btn.style.background = c;
+    btn.onclick = () => setColor(c);
+    container.appendChild(btn);
+  });
+  const picker = document.getElementById('colorPicker');
+  picker.oninput = (e) => setColor(e.target.value);
+}

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -1,0 +1,26 @@
+import { setTool, setBrushSize, state } from '../state.js';
+import { exportPNG } from '../services/exportService.js';
+import { loadExample } from '../services/galleryService.js';
+import { loadFile, getImage } from '../services/canvasService.js';
+
+export function initToolbar() {
+  document.getElementById('brush').onclick = () => setTool('brush');
+  document.getElementById('bucket').onclick = () => setTool('bucket');
+  document.getElementById('eraser').onclick = () => setTool('eraser');
+  document.getElementById('brushSize').oninput = (e) => setBrushSize(parseInt(e.target.value));
+  document.getElementById('export').onclick = exportPNG;
+
+  document.getElementById('imageLoader').onchange = async (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      await loadFile(file);
+      state.history.clear();
+      state.history.push(getImage());
+    }
+  };
+
+  document.getElementById('gallery').onchange = (e) => {
+    const val = e.target.value;
+    if (val) loadExample(val);
+  };
+}

--- a/js/utils/floodFill.js
+++ b/js/utils/floodFill.js
@@ -1,0 +1,33 @@
+export function floodFill(imageData, x, y, fillColor, tolerance = 0) {
+  const { width, height, data } = imageData;
+  const stack = [[x, y]];
+  const offset = (y * width + x) * 4;
+  const target = [data[offset], data[offset + 1], data[offset + 2], data[offset + 3]];
+
+  if (sameColor(target, fillColor)) return;
+
+  const withinTolerance = (i) =>
+    Math.abs(data[i] - target[0]) <= tolerance &&
+    Math.abs(data[i + 1] - target[1]) <= tolerance &&
+    Math.abs(data[i + 2] - target[2]) <= tolerance &&
+    Math.abs(data[i + 3] - target[3]) <= tolerance;
+
+  while (stack.length) {
+    const [cx, cy] = stack.pop();
+    if (cx < 0 || cy < 0 || cx >= width || cy >= height) continue;
+    const idx = (cy * width + cx) * 4;
+    if (!withinTolerance(idx)) continue;
+    data[idx] = fillColor[0];
+    data[idx + 1] = fillColor[1];
+    data[idx + 2] = fillColor[2];
+    data[idx + 3] = 255;
+    stack.push([cx + 1, cy]);
+    stack.push([cx - 1, cy]);
+    stack.push([cx, cy + 1]);
+    stack.push([cx, cy - 1]);
+  }
+}
+
+function sameColor(a, b) {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3];
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "coloreame-canvas",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/runner.js"
+  }
+}

--- a/tests/assert.js
+++ b/tests/assert.js
@@ -1,0 +1,5 @@
+export function equal(actual, expected, message = '') {
+  if (actual !== expected) {
+    throw new Error(`${message} expected ${expected} but got ${actual}`);
+  }
+}

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,0 +1,14 @@
+import History from '../js/services/historyService.js';
+import { equal } from './assert.js';
+
+export default function testHistory() {
+  const h = new History();
+  h.push(1);
+  h.push(2);
+  h.push(3);
+  equal(h.undo(), 2, 'undo');
+  equal(h.undo(), 1, 'second undo');
+  equal(h.redo(), 2, 'redo');
+  h.push(4);
+  equal(h.redo(), null, 'redo at end');
+}

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,0 +1,15 @@
+import testHistory from './history.test.js';
+import testStorage from './storage.test.js';
+
+const tests = [testHistory, testStorage];
+let passed = 0;
+for (const t of tests) {
+  try {
+    t();
+    console.log(`✓ ${t.name}`);
+    passed++;
+  } catch (e) {
+    console.error(`✗ ${t.name} - ${e.message}`);
+  }
+}
+console.log(`${passed}/${tests.length} tests passed`);

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,10 @@
+import { save, load } from '../js/services/storageService.js';
+import { equal } from './assert.js';
+
+export default function testStorage() {
+  save('key', { a: 1 });
+  const val = load('key', {});
+  equal(val.a, 1, 'load saved value');
+  const def = load('missing', 42);
+  equal(def, 42, 'default value');
+}

--- a/workers/floodFill.js
+++ b/workers/floodFill.js
@@ -1,0 +1,7 @@
+import { floodFill } from '../js/utils/floodFill.js';
+
+self.onmessage = (e) => {
+  const { imageData, x, y, color, tolerance } = e.data;
+  floodFill(imageData, x, y, color, tolerance);
+  postMessage(imageData, [imageData.data.buffer]);
+};


### PR DESCRIPTION
## Summary
- Default to bucket tool and track flood fills in history
- Support loading local images and built-in gallery drawings
- Add color palette for quick color selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3daefebd883269fd705af31a18a3a